### PR TITLE
requirements.txt syntax error fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ isbnlib>=3.3.8
 flup6>=1.1
 langid>=1.1.6
 lxml>=3.7.2
-jdatetime>=1.8.1,
+jdatetime>=1.8.1
 regex>=2017.1.17


### PR DESCRIPTION
`pip install -r requirements.txt` dies because of a trivial syntax error, which is fixed in this PR.

Two related comments:

It was not obvious for me how to start the server locally. `python main.py` seem to work, but I’m not sure that is the intended way. If it is, maybe it should be added to the readme?

flup is included in `requirements.txt`, which seems to result in that `python main.py` dies with various cryptic flup-related errors. So I removed flup, and then everything worked fine. Maybe there should be a warning about this in the readme also?